### PR TITLE
fix: add missing dynamic range compression to _mel_spectrogram to fix bug of voice clone

### DIFF
--- a/nano-qwen3tts-vllm/interface.py
+++ b/nano-qwen3tts-vllm/interface.py
@@ -432,6 +432,7 @@ class Qwen3TTSInterface:
         # mel_basis shape: [num_mels, freq_bins]
         # Result: [batch, num_mels, time] or [num_mels, time]
         mel_spec = torch.matmul(mel_basis, spec)  # matmul handles batch dimension correctly
+        mel_spec = torch.log(torch.clamp(mel_spec, min=1e-5))
         
         return mel_spec
     


### PR DESCRIPTION
Voice cloning is broken because `_mel_spectrogram()` is missing the dynamic 
range compression step (log + clamp) after the mel filterbank matmul.

The official Qwen3-TTS uses `dynamic_range_compression_torch()` which does 
`torch.log(torch.clamp(x, min=1e-5))` after `matmul(mel_basis, spec)`. 
Without this, the speaker encoder receives linear-scale values instead of 
log-scale, producing completely wrong speaker embeddings (cosine similarity 
0.57 vs 1.0 with the fix).

One-line fix in `_mel_spectrogram()`.